### PR TITLE
LOR-37: Refresh content for 2022 stocking drive

### DIFF
--- a/src/app/pages/stocking-signup/stocking-signup.component.html
+++ b/src/app/pages/stocking-signup/stocking-signup.component.html
@@ -1,61 +1,57 @@
 
 <div class="container">
-    <h2>Sign up to contribute to the Lowcountry Orphan Relief Stocking Drive which is being coordinated in Cane Bay by Jeannette Meeks.</h2>
+    <h2>Sign up to participate in the Lowcountry Orphan Relief Stocking Drive in 2022, coordinated in Cane Bay by Jeannette Meeks.</h2>
+
+    <p>With your help, the LOR stocking drive sponsored 2,508 children in need last year. Thank you to the Cane Bay and surrounding community for sponsoring 230 stockings!</p>
 
     <mat-accordion>
 
-        <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = false">
+        <mat-expansion-panel [expanded]="true">
             <mat-expansion-panel-header>
               <mat-panel-title>
-                How it works - Steps for Cane Bay
+                How to participate - Steps for Cane Bay
               </mat-panel-title>
             </mat-expansion-panel-header>
             <ol>
-                <li>Submit the form below.</li>
-                <li>We will get the number of stockings you request distributed to you - if picking up from us, we will set them outside our door 
-                    (210 Witch Hazel Street in Lindera) with your name attached. Otherwise they will be emailed.</li>
-                <li>Be sure to read the FAQs below.</li>
-                <li>Go shopping for the items on your list.</li>
-                <li>Drop the <strong>unwrapped</strong> items on our porch (210 Witch Hazel Street in Lindera) so that we can deliver to LOR (Or you are 
-                    welcomed to deliver to LOR yourself).</li>
+                <li>Sign up <strong>before December 9th</strong> by submitting the form below and entering the number of stockings you would like to sponsor.</li>
+                <li>We will get the number of stockings you request distributed to you - the options are emailed or pickup.
+                    <ul>
+                        <li>If selecting email delivery, the stocking will be emailed to the email address you provide within a day or two.</li>
+                        <li>If picking up, you can pickup <strong>before December 9th</strong> from our residence at 210 Witch Hazel Street in Lindera.</li>
+                    </ul>
+                </li>
+                <li><strong>Read the FAQs below</strong> - all participants, not just the one signing up.</li>
+                <li><strong>Go shopping</strong> for the items on your list. <strong>Do not worry about purchasing exact sizes.</strong> LOR will get the correct sizes into the right hands.</li>
+                <li>Return the <strong>unwrapped</strong> items on our porch (210 Witch Hazel Street in Lindera) <strong>before December 12th</strong> so that we can deliver to LOR.</li>
                 <li>After dropping the items on the porch, send a text to the number we have posted on our door and include your name (or the name that was 
                     entered on the signup form) to let us know the stockings have been returned.</li>
+                <li>You are also welcomed to deliver to LOR yourself <strong>by December 19th.</strong></li>
             </ol>
         </mat-expansion-panel>
 
-        <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = false">
+        <mat-expansion-panel>
             <mat-expansion-panel-header>
               <mat-panel-title>
-                Stocking drive FAQs from LOR - Make your gift-giving easy!
+                Stocking drive FAQs - Make your gift-giving easy!
               </mat-panel-title>
             </mat-expansion-panel-header>
             <ul>
                 <li>You do not have to purchase everything on your list. Buy whatever you feel comfortable with!</li>
                 <li>Please <strong>do not wrap</strong> the presents.</li>
-                <li>Don't get stressed out about the sizes. If you end up buying a size bigger/smaller or if it gets confusing
-                    (different stores have different sizing methods), then don't worry about it. We will get the sizes into the right hands!</li>
-                <li><strong>NO toys, puzzles, or games.</strong> If you would like to add a "little extra" to your gift, you can bring: stuffed animals, books,
+                <li>Don't get stressed out about the sizes. If you end up buying a size bigger/smaller or if it gets confusing,
+                    then don't worry about it. We will get the sizes into the right hands!</li>
+                <li><strong>Please - NO toys, puzzles, or games.</strong> If you would like to add a "little extra" to your gift, you can bring: stuffed animals, books,
                     school supplies, backpacks, pajamas, socks, water bottles, small soft blankets, accessories, toiletries, diapers/pull ups, wipes & journals.</li>
                 <li>Lowcountry Orphan Relief does NOT have children on site. LOR packs Care Kits for children who are referred to us from schools,
                     local agencies/organizations, churches, and group homes. We pack 2 full weeks of clothing and necessities into each Care Kit,
                     so the children have what they need during their transition. Your gifts will be part of the larger Care Kit given to children
                     throughout the year!</li>
+                <li>We coordinate this drive every year for the Cane Bay neighborhoods as a way to serve our community and help those that are a part of the community to 
+                    easily contribute. However, if you would like to participate directly with Low Country Orphan Relief
+                    you are welcomed to reach out to them directly on their website <a target="_blank" href="https://lowcountryorphanrelief.org">lowcountryorphanrelief.org</a>.
+                </li>
                 <li>For all other questions or concerns, please email Jeannette at 
                     <a href="mailto:jean.m.meeks@gmail.com?subject=LOR Stocking Drive">jean.m.meeks@gmail.com</a>. Thank You!</li>
-            </ul>
-        </mat-expansion-panel>
-
-        <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = false">
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Dates to remember
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <ul>
-                <li>Last day to get stockings is <strong>December 3, 2021</strong>.</li> 
-                <li>Stockings need to be returned to our residence by <strong>December 5, 2021</strong> so that they can be returned to LOR by the deadline.</li>
-                <li>If not able to return to us in time or need to return to LOR yourself, stockings must be between <strong>December 6, 2021 - December 10, 2021</strong> to LOR's location
-                    at <strong>1850 Truxton Avenue, 29404</strong> (the old Navel Base).</li>
             </ul>
         </mat-expansion-panel>
     </mat-accordion>

--- a/src/app/pages/stocking-signup/stocking-signup.component.ts
+++ b/src/app/pages/stocking-signup/stocking-signup.component.ts
@@ -27,7 +27,7 @@ export class StockingSignupComponent {
   });
 
   stockingOptions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  receiptOptions = [{label: 'Pickup from Meeks residence', val: 'home'}, {label: 'Send via email', val: 'email'}];
+  receiptOptions = [{label: 'Send via email', val: 'email'}, {label: 'Pickup from Meeks residence', val: 'home'}];
   panelOpenState = false;
   submittingForm = false;
 


### PR DESCRIPTION
Refresh the content for the LOR 2022 stocking drive.

- Update pickup and return dates with inline content
- Add FAQ for reaching out to LOR directly
- Align the FAQs and participation steps to the LOR website
- Update intro and thank you for contributions last year
- Remove the obsolete date panel
- Make email the first delivery option